### PR TITLE
SetParameters & 64-bits

### DIFF
--- a/Voicemeeter/Remote.cs
+++ b/Voicemeeter/Remote.cs
@@ -62,6 +62,16 @@ namespace VoiceMeeter
             TestResult(RemoteWrapper.SetParameter(parameter, value));
         }
 
+
+        /// <summary>
+        /// Set one or several parameters by a script
+        /// </summary>
+        /// <param name="parameters">One or more instructions separated by comma, semicolon or newline</param>
+        public static void SetParameters(string parameters)
+        {
+            TestResult(RemoteWrapper.SetParameters(parameters));
+        }
+
         #endregion
 
         #region Commands
@@ -190,15 +200,24 @@ namespace VoiceMeeter
             {
                 // Find current version from the registry
                 const string key = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall";
+                const string key32 = @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall";
                 const string uninstKey = "VB:Voicemeeter {17359A74-1236-5467}";
                 var voicemeeter = Registry.GetValue($"{key}\\{uninstKey}", "UninstallString", null);
+
+                if (voicemeeter == null && Environment.Is64BitProcess)
+                {
+                    // Fall back to 32-bits registry
+                    voicemeeter = Registry.GetValue($"{key32}\\{uninstKey}", "UninstallString", null);
+                }
+
                 if (voicemeeter == null)
                 {
                     throw new Exception("Voicemeeter not installed");
                 }
 
                 handle = Wrapper.LoadLibrary(
-                    System.IO.Path.Combine(System.IO.Path.GetDirectoryName(voicemeeter.ToString()), "VoicemeeterRemote.dll"));
+                    System.IO.Path.Combine(System.IO.Path.GetDirectoryName(voicemeeter.ToString()), 
+                        Environment.Is64BitProcess ? "VoicemeeterRemote64.dll" : "VoicemeeterRemote.dll"));
             }
 
             var startVoiceMeeter = voicemeeterType != RunVoicemeeterParam.None;

--- a/Voicemeeter/RemoteWrapper.cs
+++ b/Voicemeeter/RemoteWrapper.cs
@@ -1,13 +1,86 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Voicemeeter
 {
     internal static class RemoteWrapper
+    {
+        internal static int LoginVoicemeeter()
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.LoginVoicemeeter()
+                : RemoteWrapper32.LoginVoicemeeter();
+        }
+        
+        internal static int Logout()
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.Logout()
+                : RemoteWrapper32.Logout();
+        }
+
+        internal static int InternalRunVoicemeeter(int voicemeterType)
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.InternalRunVoicemeeter(voicemeterType)
+                : RemoteWrapper32.InternalRunVoicemeeter(voicemeterType);
+        }
+
+        internal static int GetParameter(string szParamName, ref float value)
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.GetParameter(szParamName, ref value)
+                : RemoteWrapper32.GetParameter(szParamName, ref value);
+        }
+
+        internal static int SetParameter(string szParamName, float value)
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.SetParameter(szParamName, value)
+                : RemoteWrapper32.SetParameter(szParamName, value);
+        }
+
+        internal static int InternalGetParameterW(string szParamName, StringBuilder value)
+        {
+
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.InternalGetParameterW(szParamName, value)
+                : RemoteWrapper32.InternalGetParameterW(szParamName, value);
+        }
+
+        internal static int InternalSetParameterW(string szParamName, string value)
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.InternalSetParameterW(szParamName, value)
+                : RemoteWrapper32.InternalSetParameterW(szParamName, value);
+        }
+
+        internal static int IsParametersDirty()
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.IsParametersDirty()
+                : RemoteWrapper32.IsParametersDirty();
+        }
+
+        internal static int GetLevel(int nType, int nuChannel, ref float value)
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.GetLevel(nType, nuChannel, ref value)
+                : RemoteWrapper32.GetLevel(nType, nuChannel, ref value);
+
+        }
+
+        public static int SetParameters(string szParameters)
+        {
+            return Environment.Is64BitProcess
+                ? RemoteWrapper64.SetParameters(szParameters)
+                : RemoteWrapper32.SetParameters(szParameters);
+        }
+    }
+    
+    
+    internal static class RemoteWrapper32
     {
         [DllImport("VoicemeeterRemote.dll", EntryPoint = "VBVMR_Login", CallingConvention = CallingConvention.StdCall)]
         internal static extern int LoginVoicemeeter();
@@ -61,5 +134,72 @@ namespace Voicemeeter
         // long __stdcall VBVMR_GetLevel(long nType, long nuChannel, float* pValue);
         [DllImport("VoicemeeterRemote.dll", EntryPoint = "VBVMR_GetLevel")]
         internal static extern int GetLevel(int nType, int nuChannel, ref float value);
+
+        // long __stadcall VBVMR_SetParameters(char* szParameters)
+        // long __stadcall VBVMR_SetParameters(unsigned short* szParameters)
+        [DllImport("VoicemeeterRemote.dll", EntryPoint = "VBVMR_SetParametersW", CallingConvention = CallingConvention.StdCall)]
+        public static extern int SetParameters([MarshalAs(UnmanagedType.LPWStr)] string szParameters);
+    }
+
+
+    internal static class RemoteWrapper64
+    {
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_Login", CallingConvention = CallingConvention.StdCall)]
+        internal static extern int LoginVoicemeeter();
+
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_Logout")]
+        internal static extern int Logout();
+
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_RunVoicemeeter")]
+        internal static extern int InternalRunVoicemeeter(int voicemeterType);
+
+        // Get/Set Parameters return codes
+        // returns 0: OK (no error).
+        //        -1: error
+        //        -2: no server.
+        //        -3: unknown parameter
+        //        -5: structure mismatch
+
+        // long __stdcall VBVMR_GetParameterFloat(char * szParamName, float * pValue);
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_GetParameterFloat")]
+        internal static extern int GetParameter(string szParamName, ref float value);
+
+        // long __stdcall VBVMR_SetParameterFloat(char * szParamName, float Value);
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_SetParameterFloat")]
+        internal static extern int SetParameter(string szParamName, float value);
+
+        //long __stdcall VBVMR_GetParameterStringA(char* szParamName, char* szString);
+        //long __stdcall VBVMR_GetParameterStringW(char* szParamName, unsigned short* wszString);
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_GetParameterStringW", CallingConvention = CallingConvention.StdCall)]
+        internal static extern int InternalGetParameterW(
+            [MarshalAs(UnmanagedType.LPStr)] string szParamName,      // char*
+            [MarshalAs(UnmanagedType.LPWStr)] StringBuilder value);   // unsigned short*
+
+        // long __stdcall VBVMR_SetParameterStringA(char* szParamName, char* szString);
+        // long __stdcall VBVMR_SetParameterStringW(char* szParamName, unsigned short* wszString);
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_SetParameterStringW", CallingConvention = CallingConvention.StdCall)]
+        internal static extern int InternalSetParameterW(
+            [MarshalAs(UnmanagedType.LPStr)] string szParamName,      // char*
+            [MarshalAs(UnmanagedType.LPWStr)] string value);          // unsigned short*
+
+        // Check if parameters have changed.
+        // Call this function periodically (typically every 10 or 20ms).
+        // (this function must be called from one thread only)
+        // returns:	 0: no new paramters.
+        //  		 1: New parameters -> update your display.
+        //			-1: error(unexpected)
+        //			-2: no server.
+        // long __stdcall VBVMR_IsParametersDirty(void);
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_IsParametersDirty")]
+        internal static extern int IsParametersDirty();
+
+        // long __stdcall VBVMR_GetLevel(long nType, long nuChannel, float* pValue);
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_GetLevel")]
+        internal static extern int GetLevel(int nType, int nuChannel, ref float value);
+
+        // long __stadcall VBVMR_SetParameters(char* szParameters)
+        // long __stadcall VBVMR_SetParameters(unsigned short* szParameters)
+        [DllImport("VoicemeeterRemote64.dll", EntryPoint = "VBVMR_SetParametersW", CallingConvention = CallingConvention.StdCall)]
+        public static extern int SetParameters([MarshalAs(UnmanagedType.LPWStr)] string szParameters);
     }
 }

--- a/Voicemeeter/Voicemeeter.csproj
+++ b/Voicemeeter/Voicemeeter.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
-    <PackageReference Include="System.Reactive.Linq" Version="4.2.0" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/VoicemeeterTest/UnitTest1.cs
+++ b/VoicemeeterTest/UnitTest1.cs
@@ -177,5 +177,16 @@ namespace VoiceMeeterTest
                 Assert.IsTrue(results.Count > 1);
             }
         }
+
+
+        [TestMethod]
+        [Ignore]
+        public async Task TestSetParameters()
+        {
+            using (var _ = await VoiceMeeter.Remote.Initialize(Voicemeeter.RunVoicemeeterParam.VoicemeeterPotato).ConfigureAwait(false))
+            {
+                VoiceMeeter.Remote.SetParameters("Strip[3].A1 = 1; Strip[3].A2 = 0");
+            }
+        }
     }
 }


### PR DESCRIPTION
Thanks for the library, it saved me a lot of trouble!

I was missing one feature though, the "SetParameters" method which can be called with a script, which was easy to add.

While testing I also ran into issues finding and loading the VoiceMeeter.dll when using it from a 64-bits host process, so I added a tiny layer which swaps between the two versions depending on the environment. 

I've only tested it on one system with VoiceMeeter Banana, but if you feel like the changes are worth merging into your version, here's the pull request.

Cheers,
Mark